### PR TITLE
Emit with Callback Node, Connection Auth added and updated packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Original Listener:
 Listener with callback:
 
 > Socket.IO Connector -> Socket.IO Listener In -> Payload -> Socket.IO Listener Out
-![How to use](https://raw.githubusercontent.com/nateainsworth/Git-docs-images/master/node-red-contrib-socketio-client/listener%20with%20callback.png "How to use")
+![How to use](https://raw.githubusercontent.com/isaacvitor/generalcontent/master/node-red-contrib-socketio-client/listener%20with%20callback.png "How to use")
 
 ## ToDo
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # node-red-contrib-socketio-client
 ---
+## Latest Features
+ - Removed Conflicts with node-red-contrib-socketio-extended for server integrations
+
 
 ## Nodes
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 1. Socket.IO Connector
 2. Socket.IO Listener
+3. Socket.IO Emitter
+4. Socket.IO Emitter With Callback
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,16 @@
 6. Socket.IO Listener out, for use with callback listener in
 
 ## How to use
+Original Listener:
 
 > Socket.IO Connector -> Socket.IO Listener -> Payload
 
 ![How to use](https://raw.githubusercontent.com/isaacvitor/generalcontent/master/node-red-contrib-socketio-client/nodered_socketio_ex01.png "How to use")
 
+Listener with callback:
+
+> Socket.IO Connector -> Socket.IO Listener In -> Payload -> Socket.IO Listener Out
+![How to use](https://raw.githubusercontent.com/nateainsworth/Git-docs-images/master/node-red-contrib-socketio-client/listener%20with%20callback.png "How to use")
 
 ## ToDo
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # node-red-contrib-socketio-client
 ---
 ## Latest Features
- - Removed Conflicts with node-red-contrib-socketio-extended for server integrations
-
+ - Removed Conflicts with node-red-contrib-socketio-extended for server integrations.
+ - Added two listener nodes listener in and listener out for use with callback.
+ - Colour coded call back nodes.
 
 ## Nodes
 
 1. Socket.IO Connector
 2. Socket.IO Listener
 3. Socket.IO Emitter
-4. Socket.IO Emitter With Callback
+4. Socket.IO Emitter with Callback
+5. Socket.IO Listener in, for use with callback listener out
+6. Socket.IO Listener out, for use with callback listener in
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 Original Listener:
 
 > Socket.IO Connector -> Socket.IO Listener -> Payload
-
 ![How to use](https://raw.githubusercontent.com/isaacvitor/generalcontent/master/node-red-contrib-socketio-client/nodered_socketio_ex01.png "How to use")
 
 Listener with callback:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-socketio-client",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-socketio-client",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "MIT",
       "dependencies": {
         "socket.io-client": "^4.6.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,46 +3,179 @@
   "version": "0.4.9",
   "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "after": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha512-QbJ0NTQ/I9DI3uSJA4cbexiwQeRAfjPScqIbSjUDd9TOrcg6pTkdgziesOqxBMBzit8vFCTwrP27t13vFOORRA=="
+  "packages": {
+    "": {
+      "name": "node-red-contrib-socketio-client",
+      "version": "0.4.9",
+      "license": "MIT",
+      "dependencies": {
+        "socket.io-client": "^4.6.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA=="
+    "node_modules/component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
-    "base64-arraybuffer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
-      "integrity": "sha512-a1eIFi4R9ySrbiMuyTGx5e92uRH5tQY6kArNcFaKBUleIoLjdjBg7Zxm3Mqm3Kmkf27HLR/1fnxX9q8GQ7Iavg=="
+    "node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
     },
-    "node_modules/ms": {
+    "node_modules/engine.io-client": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
+      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.11.0",
+        "xmlhttprequest-ssl": "~2.0.0"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "component-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha512-WZveuKPeKAG9qY+FkYDeADzdHyTYdIboXS59ixDeRJL5ZhxpqUnxSOwop4FQjMsiYm3/Or8cegVbpAHNA7pHxw=="
+    "node_modules/engine.io-parser": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
+      "integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+      "integrity": "sha512-c2cu3UxbI+b6kR3fy0nRnAhodsvR9dx7U5+znCOzdj6IfP3upFURTr0Xl5BlQZNKZjEtxrmVyfSdeE3O57smoQ=="
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/node_modules/@socket.io/component-emitter": {
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+      "extraneous": true
+    },
+    "node_modules/node_modules/ms": {
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "extraneous": true
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.1.tgz",
+      "integrity": "sha512-5UswCV6hpaRsNg5kkEHVcbBIXEYoVbMQaHJBXJCyEQ+CiFPV1NIOY0XOFWG4XR4GZcB8Kn6AsRs/9cy9TbqVMQ==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.4.0",
+        "socket.io-parser": "~4.2.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-client/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.2.tgz",
+      "integrity": "sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==",
+      "dependencies": {
+        "component-emitter": "~1.3.0",
+        "debug": "~3.1.0",
+        "isarray": "2.0.1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-    },
-    "component-inherit": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha512-w+LhYREhatpVqTESyGFg3NlP6Iu0kEKUHETY9GoZP/pQyW4mHFZuFWRUCIqVPZ36ueVLtoOEZaAqbCF2RDndaA=="
     },
     "debug": {
       "version": "3.1.0",
@@ -53,52 +186,36 @@
       }
     },
     "engine.io-client": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.3.tgz",
-      "integrity": "sha512-qsgyc/CEhJ6cgMUwxRRtOndGVhIu5hpL5tR4umSpmX/MvkFoIxUTM7oFMDQumHNzlNLwSVy6qhstFPoWTf7dOw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
+      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
       "requires": {
-        "component-emitter": "~1.3.0",
-        "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.2.0",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parseqs": "0.0.6",
-        "parseuri": "0.0.6",
-        "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.6.2",
-        "yeast": "0.1.2"
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.11.0",
+        "xmlhttprequest-ssl": "~2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "engine.io-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
-      "integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
-      "requires": {
-        "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
-        "base64-arraybuffer": "0.1.4",
-        "blob": "0.0.5",
-        "has-binary2": "~1.0.2"
-      }
-    },
-    "has-binary2": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
-      "requires": {
-        "isarray": "2.0.1"
-      }
-    },
-    "has-cors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha512-g5VNKdkFuUuVCP9gYfDJHjK2nqdQJ7aDLTnycnc2+RvsOQbuLdF5pm7vuE5J76SEBIQjs4kQY/BWq74JUmjbXA=="
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
+      "integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw=="
     },
     "isarray": {
       "version": "2.0.1",
@@ -110,32 +227,30 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
-    "parseqs": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
-      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
-    },
-    "parseuri": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
-    },
     "socket.io-client": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.5.0.tgz",
-      "integrity": "sha512-lOO9clmdgssDykiOmVQQitwBAF3I6mYcQAo7hQ7AM6Ny5X7fp8hIJ3HcQs3Rjz4SoggoxA1OgrQyY8EgTbcPYw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.1.tgz",
+      "integrity": "sha512-5UswCV6hpaRsNg5kkEHVcbBIXEYoVbMQaHJBXJCyEQ+CiFPV1NIOY0XOFWG4XR4GZcB8Kn6AsRs/9cy9TbqVMQ==",
       "requires": {
-        "backo2": "1.0.2",
-        "component-bind": "1.0.0",
-        "component-emitter": "~1.3.0",
-        "debug": "~3.1.0",
-        "engine.io-client": "~3.5.0",
-        "has-binary2": "~1.0.2",
-        "indexof": "0.0.1",
-        "parseqs": "0.0.6",
-        "parseuri": "0.0.6",
-        "socket.io-parser": "~3.3.0",
-        "to-array": "0.1.4"
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.4.0",
+        "socket.io-parser": "~4.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "socket.io-parser": {
@@ -148,25 +263,16 @@
         "isarray": "2.0.1"
       }
     },
-    "to-array": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "integrity": "sha512-LhVdShQD/4Mk4zXNroIQZJC+Ap3zgLcDuwEdcmLv9CCO73NWockQDwyUnW/m8VX/EElfL6FcYx7EeutN4HJA6A=="
-    },
     "ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "requires": {}
     },
     "xmlhttprequest-ssl": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
-      "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q=="
-    },
-    "yeast": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha512-8HFIh676uyGYP6wP13R/j6OJ/1HwJ46snpvzE7aHAN3Ryqh2yX6Xox2B4CUmTwwOIzlG3Bs7ocsP5dZH/R1Qbg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
-  "name": "node-red-contrib-socketio-client",
-  "version": "0.4.8",
+  "name": "node-red-contrib-socketio-client-jwt",
+  "version": "0.4.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "node-red-contrib-socketio-client",
-      "version": "0.4.8",
+      "name": "node-red-contrib-socketio-client-jwt",
+      "version": "0.4.9",
       "license": "MIT",
       "dependencies": {
         "socket.io-client": "^4.6.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@socket.io/component-emitter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,234 +1,184 @@
 {
   "name": "node-red-contrib-socketio-client",
   "version": "0.4.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "after": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
-    },
-    "arraybuffer.slice": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
-    },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
-    },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
-    },
-    "base64-arraybuffer": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
-    },
-    "better-assert": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "requires": {
-        "callsite": "1.0.0"
-      }
-    },
-    "blob": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
-      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
-    },
-    "callsite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
-    },
-    "component-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
-    },
-    "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-    },
-    "component-inherit": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
-    },
-    "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "requires": {
-        "ms": "^2.1.1"
-      }
-    },
-    "engine.io-client": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.3.tgz",
-      "integrity": "sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==",
-      "requires": {
-        "component-emitter": "~1.3.0",
-        "component-inherit": "0.0.3",
-        "debug": "~4.1.0",
-        "engine.io-parser": "~2.2.0",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "ws": "~6.1.0",
-        "xmlhttprequest-ssl": "~1.5.4",
-        "yeast": "0.1.2"
-      },
+  "packages": {
+    "": {
+      "name": "node-red-contrib-socketio-client",
+      "version": "0.4.0",
+      "license": "MIT",
       "dependencies": {
-        "component-emitter": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+        "socket.io-client": "^4.6.1"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
         }
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
+      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.11.0",
+        "xmlhttprequest-ssl": "~2.0.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
+      "integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.1.tgz",
+      "integrity": "sha512-5UswCV6hpaRsNg5kkEHVcbBIXEYoVbMQaHJBXJCyEQ+CiFPV1NIOY0XOFWG4XR4GZcB8Kn6AsRs/9cy9TbqVMQ==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.4.0",
+        "socket.io-parser": "~4.2.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.2.tgz",
+      "integrity": "sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "engine.io-client": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
+      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.11.0",
+        "xmlhttprequest-ssl": "~2.0.0"
+      }
+    },
     "engine.io-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
-      "integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
-      "requires": {
-        "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
-        "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.5",
-        "has-binary2": "~1.0.2"
-      }
-    },
-    "has-binary2": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
-      "requires": {
-        "isarray": "2.0.1"
-      }
-    },
-    "has-cors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-    },
-    "isarray": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-      "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
+      "integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw=="
     },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "object-component": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
-    },
-    "parseqs": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "requires": {
-        "better-assert": "~1.0.0"
-      }
-    },
-    "parseuri": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "requires": {
-        "better-assert": "~1.0.0"
-      }
-    },
     "socket.io-client": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
-      "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.1.tgz",
+      "integrity": "sha512-5UswCV6hpaRsNg5kkEHVcbBIXEYoVbMQaHJBXJCyEQ+CiFPV1NIOY0XOFWG4XR4GZcB8Kn6AsRs/9cy9TbqVMQ==",
       "requires": {
-        "backo2": "1.0.2",
-        "base64-arraybuffer": "0.1.5",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "~4.1.0",
-        "engine.io-client": "~3.4.0",
-        "has-binary2": "~1.0.2",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "socket.io-parser": "~3.3.0",
-        "to-array": "0.1.4"
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.4.0",
+        "socket.io-parser": "~4.2.1"
       }
     },
     "socket.io-parser": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.3.tgz",
-      "integrity": "sha512-qOg87q1PMWWTeO01768Yh9ogn7chB9zkKtQnya41Y355S0UmpXgpcrFwAgjYJxu9BdKug5r5e9YtVSeWhKBUZg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.2.tgz",
+      "integrity": "sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==",
       "requires": {
-        "component-emitter": "~1.3.0",
-        "debug": "~3.1.0",
-        "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        }
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
       }
-    },
-    "to-array": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
     },
     "ws": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
-      "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "requires": {}
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
-    },
-    "yeast": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-socketio-client",
-  "version": "0.4.0",
+  "version": "0.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-socketio-client",
-      "version": "0.4.0",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "socket.io-client": "^4.6.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-socketio-client",
-  "version": "0.4.5",
+  "version": "0.4.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-socketio-client",
-      "version": "0.4.5",
+      "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
         "socket.io-client": "^4.6.1"

--- a/package.json
+++ b/package.json
@@ -28,10 +28,9 @@
     "nodes": {
       "socketio-client": "socketio-client/socketio-client.js"
     }
-  }
-  {
-    "engines": {
+  },
+  "engines": {
       "node": ">=12.0.0"
-    }
   }
+
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-socketio-client-jwt",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Node Red client to work with socket.io server with JWT option",
   "main": "index.js",
   "scripts": {
@@ -30,7 +30,6 @@
     }
   },
   "engines": {
-      "node": ">=12.0.0"
+    "node": ">=12.0.0"
   }
-
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-socketio-client-jwt",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Node Red client to work with socket.io server with JWT option",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/isaacvitor/node-red-contrib-socketio-client.git"
+    "url": "git+https://github.com/nateainsworth/node-red-contrib-socketio-client.git"
   },
   "keywords": [
     "node-red",
@@ -17,9 +17,9 @@
   "author": "Isaac Vitor",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/isaacvitor/node-red-contrib-socketio-client/issues"
+    "url": "https://github.com/nateainsworth/node-red-contrib-socketio-client/issues"
   },
-  "homepage": "https://github.com/isaacvitor/node-red-contrib-socketio-client.git#readme",
+  "homepage": "https://github.com/nateainsworth/node-red-contrib-socketio-client#readme",
   "dependencies": {
     "socket.io-client": "^4.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/isaacvitor/node-red-contrib-socketio-client.git#readme",
   "dependencies": {
-    "socket.io-client": "^2.3.0"
+    "socket.io-client": "^4.6.1"
   },
   "node-red": {
     "nodes": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-socketio-client-jwt",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Node Red client to work with socket.io server with JWT option",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-socketio-client-jwt",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Node Red client to work with socket.io server with JWT option",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-socketio-client-jwt",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Node Red client to work with socket.io server with JWT option",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,14 @@
     "socket.io-client": "^4.6.1"
   },
   "node-red": {
+    "version": ">=2.0.0",
     "nodes": {
       "socketio-client": "socketio-client/socketio-client.js"
+    }
+  }
+  {
+    "engines": {
+      "node": ">=12.0.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-socketio-client-jwt",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Node Red client to work with socket.io server with JWT option",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-socketio-client-jwt",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Node Red client to work with socket.io server with JWT option",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nateainsworth/node-red-contrib-socketio-client.git"
+    "url": "git+https://github.com/isaacvitor/node-red-contrib-socketio-client.git"
   },
   "keywords": [
     "node-red",
@@ -17,9 +17,9 @@
   "author": "Isaac Vitor",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/nateainsworth/node-red-contrib-socketio-client/issues"
+    "url": "https://github.com/isaacvitor/node-red-contrib-socketio-client/issues"
   },
-  "homepage": "https://github.com/nateainsworth/node-red-contrib-socketio-client#readme",
+  "homepage": "https://github.com/isaacvitor/node-red-contrib-socketio-client.git#readme",
   "dependencies": {
     "socket.io-client": "^4.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-socketio-client-jwt",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Node Red client to work with socket.io server with JWT option",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "node-red-contrib-socketio-client",
-  "version": "0.4.0",
-  "description": "Node Red client to work with socket.io server",
+  "name": "node-red-contrib-socketio-client-jwt",
+  "version": "0.4.1",
+  "description": "Node Red client to work with socket.io server with JWT option",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/socketio-client/socketio-client.html
+++ b/socketio-client/socketio-client.html
@@ -151,6 +151,100 @@
       <p>The <code>msg.payload</code> will be whole content emitted through 'event name' that you specified</p>
   </script>
 
+
+<!-- Listener In -->
+<script type="text/javascript">
+  /*global RED*/
+  RED.nodes.registerType('socketio-listener-in', {
+    category: 'socket io client',
+    inputs: 1,
+    outputs: 1,
+    color: "#8cb7c5",
+    icon: "socketio.png",
+    paletteLabel: "socketio listener in",
+    defaults: {
+      eventname: {
+        value: "",
+        required: true
+      },
+      name: {
+        value: ""
+      }
+    },
+    label: function() {
+        return ( this.name || this.eventname ) || "Socket.IO listener in";
+    }
+  });
+</script>
+
+<script type="text/x-red" data-template-name="socketio-listener-in">
+  <div class="form-row">
+    <label for="node-input-eventname"><i class="icon-tasks"></i> Event Name</label>
+    <input type="text" id="node-input-eventname" placeholder="Event Name">
+  </div>
+  <div class="form-row">
+    <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+    <input type="text" id="node-input-name" placeholder="Name">
+  </div>
+</script>
+
+<script type="text/x-red" data-help-name="socketio-listener-in">
+    <p>Socket.IO Listener In</p>
+    <p>It's works only in couple with Socket.io Connector</p>
+    <pre>Socket.IO Connector -> Socket.IO Listener In -> Payload -> Socket.IO Listener Callback Out</pre>
+    <p>The <code>msg.payload</code> will be whole content emitted through 'event name' that you specified</p>
+</script>
+
+
+<!-- Listener Callback Out -->
+<script type="text/javascript">
+  /*global RED*/
+  RED.nodes.registerType('socketio-listener-out', {
+    category: 'socket io client',
+    inputs: 1,
+    outputs: 0,
+    color: "#8cb7c5",
+    icon: "socketio.png",
+    paletteLabel: "socketio listener out",
+    defaults: {
+      eventname: {
+        value: "",
+        required: true
+      },
+      name: {
+        value: ""
+      }
+    },
+    label: function() {
+        return ( this.name || this.eventname ) || "Socket.IO listener out";
+    }
+  });
+</script>
+
+<script type="text/x-red" data-template-name="socketio-listener-out">
+  <div class="form-row">
+    <label for="node-input-eventname"><i class="icon-tasks"></i> Event Name</label>
+    <input type="text" id="node-input-eventname" placeholder="Event Name">
+  </div>
+  <div class="form-row">
+    <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+    <input type="text" id="node-input-name" placeholder="Name">
+  </div>
+</script>
+
+<script type="text/x-red" data-help-name="socketio-listener-out">
+    <p>Socket.IO Listener Callback Out</p>
+    <p>It's works only in couple with Socket.io Connector and listener In</p>
+    <pre>Socket.IO Connector -> Socket.IO Listener In -> Payload -> Socket.IO Listener Out</pre>
+    <pre>
+      msg.callback: "your message or object";
+    </pre>
+
+  msg.callback
+
+  </script>
+
+
 <!-- Emitter -->
   <script type="text/javascript">
     /*global RED*/
@@ -202,7 +296,7 @@
     category: 'socket io client',
     inputs: 1,
     outputs: 1,
-    color: "#D8BFD8",
+    color: "#8cb7c5",
     icon: "socketio.png",
     paletteLabel: "socketio callback emitter",
     defaults: {
@@ -242,5 +336,3 @@
         }
     </pre>
 </script>
-
-

--- a/socketio-client/socketio-client.html
+++ b/socketio-client/socketio-client.html
@@ -34,7 +34,7 @@
 
   </script>
 
-  <script type="text/x-red" data-template-name="socketio-config">
+  <script type="text/x-red" data-template-name="socketio-client-config">
     <div class="form-row">
       <label for="node-config-input-host"><i class="fa fa-globe"></i> Host</label>
       <input type="text" id="node-config-input-host" placeholder="e.g. http://127.0.0.1">
@@ -66,7 +66,7 @@
       defaults: {
         server: {
           value: "",
-          type: "socketio-config"
+          type: "socketio-client-config"
         },
         namespace: {
           value: "",

--- a/socketio-client/socketio-client.html
+++ b/socketio-client/socketio-client.html
@@ -192,7 +192,6 @@
     <p>Socket.IO Listener In</p>
     <p>It's works only in couple with Socket.io Connector</p>
     <pre>Socket.IO Connector -> Socket.IO Listener In -> Payload -> Socket.IO Listener Callback Out</pre>
-    <p>The <code>msg.payload</code> will be whole content emitted through 'event name' that you specified</p>
 </script>
 
 
@@ -236,9 +235,7 @@
     <p>Socket.IO Listener Callback Out</p>
     <p>It's works only in couple with Socket.io Connector and listener In</p>
     <pre>Socket.IO Connector -> Socket.IO Listener In -> Payload -> Socket.IO Listener Out</pre>
-    <pre>
-      msg.callback: "your message or object";
-    </pre>
+    <code>msg.callback: "your message or object";</code>
 
   msg.callback
 

--- a/socketio-client/socketio-client.html
+++ b/socketio-client/socketio-client.html
@@ -2,7 +2,7 @@
   <script type="text/javascript">
     "use strict";
     /*global RED*/
-    RED.nodes.registerType('socketio-config', {
+    RED.nodes.registerType('socketio-client-config', {
       category: 'config',
       defaults: {
         host: {

--- a/socketio-client/socketio-client.html
+++ b/socketio-client/socketio-client.html
@@ -37,7 +37,7 @@
   <script type="text/x-red" data-template-name="socketio-config">
     <div class="form-row">
       <label for="node-config-input-host"><i class="fa fa-globe"></i> Host</label>
-      <input type="text" id="node-config-input-host" placeholder="e.g. http://127.0.0.1/">
+      <input type="text" id="node-config-input-host" placeholder="e.g. http://127.0.0.1">
     </div>
     <div class="form-row">
       <label for="node-config-input-port"><i class="fa fa-server"></i> Port</label>
@@ -207,7 +207,12 @@
     paletteLabel: "socketio callback emitter",
     defaults: {
       name: {
-        value: ""
+        value: "",
+        required: true
+      },
+      connection: {
+        value: "",
+        required: true
       }
     },
     label: function() {
@@ -218,23 +223,23 @@
 
 <script type="text/x-red" data-template-name="socketio-callback-emitter">
   <div class="form-row">
-    <label for="node-input-name"><i class="icon-tasks"></i> Name</label>
+    <label for="node-input-name"><i class="icon-tasks"></i> Event Name</label>
     <input type="text" id="node-input-name" placeholder="Event Name">
+  </div>
+  <div class="form-row">
+    <label for="node-input-connection"><i class="icon-tasks"></i> Connection Name</label>
+    <input type="text" id="node-input-connection" placeholder="Connection Name">
   </div>
 </script>
 
 <script type="text/x-red" data-help-name="socketio-callback-emitter">
     <p>Socket.IO callback emitter</p>
-    <p>Use payload as what you want to send, also you need set msg.connectionName and msg.eventName</p>
+    <p>Use payload as what you want to send</p>
     <pre>
-      {
-        connectionName: 'connection1',
-        eventName: 'MySocketIOEvent',
         payload: {
           cmd: 'hello',
           message: 'World'
         }
-      }
     </pre>
 </script>
 

--- a/socketio-client/socketio-client.html
+++ b/socketio-client/socketio-client.html
@@ -7,12 +7,12 @@
       defaults: {
         host: {
           value: "http://localhost",
-          required: true
+          required: true,
         },
         port: {
           value: "",
           required: false,
-          validate: RED.validators.number()
+          validate: RED.validators.regex(/^(\s*|\d+)$/)
         },
         path: {
           value: "",
@@ -21,26 +21,35 @@
         reconnection: {
           value: true,
           required: false
+        },
+        token:{
+          value: "",
+          required: false,
         }
       },
       label: function() {
         return this.host + ":" + this.port + this.path;
       }
     });
+
   </script>
 
   <script type="text/x-red" data-template-name="socketio-config">
     <div class="form-row">
       <label for="node-config-input-host"><i class="fa fa-globe"></i> Host</label>
-      <input type="text" id="node-config-input-host">
+      <input type="text" id="node-config-input-host" placeholder="e.g. http://127.0.0.1/">
     </div>
     <div class="form-row">
       <label for="node-config-input-port"><i class="fa fa-server"></i> Port</label>
-      <input type="text" id="node-config-input-port">
+      <input type="text" id="node-config-input-port" placeholder="May not be required e.g 8080">
     </div>
     <div class="form-row">
       <label for="node-config-input-path"><i class="fa fa-folder"></i> Path</label>
-      <input type="text" id="node-config-input-path">
+      <input type="text" id="node-config-input-path" placeholder="May not be required e.g /socket.io/">
+    </div>
+    <div class="form-row">
+      <label for="node-config-input-token"><i class="fa fa-key"></i> JWT Token</label>
+      <textarea type="text" id="node-config-input-token" style="width: 70%;height: 100px;"></textarea>
     </div>
   </script>
 
@@ -48,7 +57,7 @@
   <script type="text/javascript">
     /*global RED*/
     RED.nodes.registerType('socketio-connector', {
-      category: 'input',
+      category: 'socket io client',
       inputs: 0,
       outputs: 1,
       color: "#D8BFD8",
@@ -103,7 +112,7 @@
   <script type="text/javascript">
     /*global RED*/
     RED.nodes.registerType('socketio-listener', {
-      category: 'function',
+      category: 'socket io client',
       inputs: 1,
       outputs: 1,
       color: "#D8BFD8",
@@ -146,7 +155,7 @@
   <script type="text/javascript">
     /*global RED*/
     RED.nodes.registerType('socketio-emitter', {
-      category: 'function',
+      category: 'socket io client',
       inputs: 1,
       outputs: 0,
       color: "#D8BFD8",
@@ -184,4 +193,49 @@
         }
       </pre>
   </script>
+
+  
+<!-- Emitter with callback -->
+<script type="text/javascript">
+  /*global RED*/
+  RED.nodes.registerType('socketio-callback-emitter', {
+    category: 'socket io client',
+    inputs: 1,
+    outputs: 1,
+    color: "#D8BFD8",
+    icon: "socketio.png",
+    paletteLabel: "socketio callback emitter",
+    defaults: {
+      name: {
+        value: ""
+      }
+    },
+    label: function() {
+        return ( this.name ) || "Socket.IO callback emitter";
+    }
+  });
+</script>
+
+<script type="text/x-red" data-template-name="socketio-callback-emitter">
+  <div class="form-row">
+    <label for="node-input-name"><i class="icon-tasks"></i> Name</label>
+    <input type="text" id="node-input-name" placeholder="Event Name">
+  </div>
+</script>
+
+<script type="text/x-red" data-help-name="socketio-callback-emitter">
+    <p>Socket.IO callback emitter</p>
+    <p>Use payload as what you want to send, also you need set msg.connectionName and msg.eventName</p>
+    <pre>
+      {
+        connectionName: 'connection1',
+        eventName: 'MySocketIOEvent',
+        payload: {
+          cmd: 'hello',
+          message: 'World'
+        }
+      }
+    </pre>
+</script>
+
 

--- a/socketio-client/socketio-client.js
+++ b/socketio-client/socketio-client.js
@@ -117,22 +117,16 @@ module.exports = function (RED) {
   function SocketIOCallbackEmitter(n) {
   RED.nodes.createNode(this, n);
   this.name = n.name;
+  this.connection = n.connection;
   this.socketId = null;
 
   let node = this;
 
   node.on('input', async (msg) => {
-    if (!msg.connectionName) {
-      throw 'msg.connectionName undefined! Please place connectionName to msg object';
+    if (!sockets[node.connection]) {
+      throw 'Connection ' + node.connection + ' not exists';
     }
-    if (!msg.eventName) {
-      throw 'msg.eventName undefined! Please place eventName to msg object';
-    }
-    if (!sockets[msg.connectionName]) {
-      throw 'Connection ' + msg.connectionName + ' not exists';
-    }
-    sockets[msg.connectionName].emit(msg.eventName, msg.payload, (response) => {
-      console.log('callback received');
+    sockets[node.connection].emit(node.name, msg.payload, (response) => {
       node.send({ payload: response });
     });
     
@@ -144,12 +138,9 @@ RED.nodes.registerType('socketio-callback-emitter', SocketIOCallbackEmitter);
     var uri = config.host;
     var options = {
       reconnection: config.reconnection,
-      transports: ['websocket'],
-      extraHeaders: {
-          "Access-Control-Allow-Origin": config.host,
-      },
       auth: {
-          token: config.token
+          token: config.token,
+          server: true
       }
     };
 

--- a/socketio-client/socketio-client.js
+++ b/socketio-client/socketio-client.js
@@ -144,7 +144,7 @@ module.exports = function (RED) {
       let message =  msg.callback.valueOf();
       if( callbacks[node.eventName] !== undefined ) {
         callbacks[node.eventName](message);
-        node.status({ fill: 'green', shape: 'ring', text: 'Callback Sent' });
+        node.status({ fill: 'green', shape: 'ring', text: 'Callback Sent' + message });
       }else{
         node.status({ fill: 'red', shape: 'ring', text: 'Event name must match listener in' });
       }

--- a/socketio-client/socketio-client.js
+++ b/socketio-client/socketio-client.js
@@ -4,7 +4,7 @@ module.exports = function (RED) {
   let sockets = {};
 
   /* sckt config */
-  function SocketIOConfig(n) {
+  function SocketIOClientConfig(n) {
     RED.nodes.createNode(this, n);
     this.host = n.host;
     this.port = n.port;
@@ -12,7 +12,7 @@ module.exports = function (RED) {
     this.token = n.token;
     this.reconnection = n.reconnection;
   }
-  RED.nodes.registerType('socketio-config', SocketIOConfig);
+  RED.nodes.registerType('socketio-client-config', SocketIOClientConfig);
 
   /* sckt connector*/
   function SocketIOConnector(n) {


### PR DESCRIPTION
Added:
- Node with callbacks on Emit.
- Auth added to config for JWT middleware securing connections.
- Port validation updated to use regex to accept a blank field or numbers.
- Updated socekt-io-client version.
- Placeholder notes to make it clearer when setting up config.

Package.json will need reversing to use the original links and name but leave in the updated socket io client version.